### PR TITLE
Add date fallback for RSS enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Responses API is preferred across the pipeline for all OpenAI calls.
 | `enrich_rss.py` | Summarise and classify RSS articles already stored in Notion. |
 | `postprocess.py` | Apply additional enrichment prompts. Used by `enrich.py` and `enrich_rss.py`. |
 | `infer_vendor.py` | Infer and set the Vendor field on existing pages. |
+| `infer_created_date.py` | Populate missing Created Date using article text. |
 
 ## Setup
 
@@ -106,6 +107,12 @@ If a feed URL points to a Substack homepage, `capture_rss.py` automatically appe
 
 ```bash
 python infer_vendor.py
+```
+
+6. Backfill missing Created Dates:
+
+```bash
+python infer_created_date.py
 ```
 
 Items older than `RSS_WINDOW_DAYS` are ignored when capturing RSS feeds.

--- a/infer_created_date.py
+++ b/infer_created_date.py
@@ -1,0 +1,79 @@
+"""
+infer_created_date.py – fill blank Created Date fields.
+
+ENV (.env)
+  NOTION_TOKEN, NOTION_SOURCES_DB
+  RSS_URL_PROP=Article URL
+  CREATED_PROP=Created Date
+"""
+import os, time, argparse
+from dotenv import load_dotenv
+from notion_client import Client as Notion
+
+from enrich_rss import fetch_article_text, extract_date_from_text, RSS_URL_PROP, CREATED_PROP
+
+load_dotenv()
+
+NOTION_DB = os.getenv("NOTION_SOURCES_DB")
+
+notion = Notion(auth=os.getenv("NOTION_TOKEN"))
+
+
+def query_pages():
+    filt = {
+        "and": [
+            {"property": RSS_URL_PROP, "url": {"is_not_empty": True}},
+            {"property": CREATED_PROP, "date": {"is_empty": True}},
+        ]
+    }
+    results = []
+    kwargs = dict(database_id=NOTION_DB, filter=filt, page_size=100)
+    while True:
+        resp = notion.databases.query(**kwargs)
+        results.extend(resp["results"])
+        if not resp.get("has_more"):
+            break
+        kwargs["start_cursor"] = resp["next_cursor"]
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Populate missing Created Dates")
+    ap.add_argument("--dry-run", action="store_true", help="Preview changes")
+    args = ap.parse_args()
+
+    rows = query_pages()
+    if not rows:
+        print("🚩 Nothing to update."); return
+    print(f"🔍 Found {len(rows)} page(s)\n")
+
+    for row in rows:
+        title = row["properties"]["Title"]["title"][0]["plain_text"]
+        url = row["properties"][RSS_URL_PROP]["url"]
+        print(f"➡️  {title}")
+        try:
+            print("   • Fetching article …")
+            text = fetch_article_text(url)
+        except Exception as exc:
+            print("   ⚠️", exc, "\n")
+            continue
+        found = extract_date_from_text(text)
+        if not found:
+            print("   ↳ No date found\n")
+            continue
+        print(f"   ↳ Date: {found}")
+        if args.dry_run:
+            print("   (dry run)\n")
+            continue
+        try:
+            notion.pages.update(row["id"], properties={
+                CREATED_PROP: {"date": {"start": found}}
+            })
+            print("   ✓ Updated\n")
+        except Exception as exc:
+            print("   ⚠️  Failed to update:", exc, "\n")
+        time.sleep(0.3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- infer Created Date from article content if feed doesn't supply one
- add `infer_created_date.py` to backfill missing Created Date values

## Testing
- `python -m py_compile *.py`
