### PR TITLE
Fix missing tool_choice type in responses call

### DIFF
--- a/enrich.py
+++ b/enrich.py
@@ -239,7 +239,7 @@ def classify(text: str) -> tuple[str, str]:
         resp = oai.responses.create(
             model=MODEL_CLASSIFIER,
             tools=[tool],
-            tool_choice={"name": "classify"},
+            tool_choice={"type": "function", "function": {"name": "classify"}},
             instructions=instructions,
             input=text[:600000],
             max_output_tokens=60,


### PR DESCRIPTION
## Summary
- update `tool_choice` parameters when using the Responses API so they include the required `type` and `function` fields

## Testing
- `python -m py_compile enrich.py`
