### PR TITLE
Dynamic classification taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ enrich the content:
 | **Vendor** | Select | Vendor or organisation name if applicable. |
 | **Created Date** | Date | Original publication or file creation time. |
 
+The values for **AI-Primitive** and **Content-Type** are fetched from the
+database schema each time the scripts run. Updating the select options in
+Notion automatically changes the classification taxonomy.
+
 For each page, the enrichment process also appends toggle blocks containing a
 detailed summary, the raw extracted text and outputs from additional analysis
 prompts. These blocks live in the page body so that readers can expand them in


### PR DESCRIPTION
## Summary
- fetch taxonomy from Notion during startup
- default to old category lists on failure
- fall back to first available category if GPT returns an unknown value
- mention dynamic classification in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c57ee87cc832e9c059495f40e25d3