### PR TITLE
Increase vendor inference token limit

### DIFF
--- a/infer_vendor.py
+++ b/infer_vendor.py
@@ -101,7 +101,7 @@ def infer_vendor_name(text: str) -> str:
             model=MODEL_VENDOR,
             instructions=prompt,
             input=text,
-            max_output_tokens=10,
+            max_output_tokens=60,
         )
         out = resp.output[0]
         answer = out.content[0].text.strip()
@@ -110,7 +110,7 @@ def infer_vendor_name(text: str) -> str:
             model=MODEL_VENDOR,
             messages=[{"role": "system", "content": prompt},
                       {"role": "user", "content": text}],
-            max_tokens=10,
+            max_tokens=60,
         )
         answer = resp.choices[0].message.content.strip()
 


### PR DESCRIPTION
## Summary
- allow more output tokens for vendor inference results

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684e035bad70832cbf7648df34da1157