### PR TITLE
Fix truncated summaries

### DIFF
--- a/enrich_rss.py
+++ b/enrich_rss.py
@@ -25,6 +25,7 @@ from enrich import (
     inbox_rows,
     add_fulltext_blocks,
     add_summary_block,
+    add_exec_summary_block,
     summarise_exec,
     summarise,
     classify,
@@ -125,6 +126,7 @@ def main():
 
             print("   • Summarising with GPT-4.1 (exec) …")
             summary = summarise_exec(article_text)
+            add_exec_summary_block(row["id"], summary)
             print("     ↳ exec summary chars:", len(summary))
 
             print("   • Classifying with GPT-4.1 …")


### PR DESCRIPTION
## Summary
- use shared `_append_toggle` helper when writing summary blocks
- include an Executive Summary toggle for full executive summary text
- chunk long text so it isn't cut off

## Testing
- `python -m py_compile enrich.py enrich_rss.py postprocess.py capture_rss.py infer_created_date.py infer_vendor.py ingest_drive.py`

------
https://chatgpt.com/codex/tasks/task_e_684e14283898832c9f60540e3d0635e2